### PR TITLE
Switch back to ASM for class generation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,10 +95,7 @@ java.withSourcesJar()
 
 dependencies {
     implementation('org.ow2.asm:asm:9.2')
-    implementation('org.ow2.asm:asm-commons:9.2')
-    implementation('org.ow2.asm:asm-tree:9.2')
     implementation('org.apache.logging.log4j:log4j-api:2.17.1')
-    implementation('cpw.mods:modlauncher:10.0.+')
     compileOnly('org.jetbrains:annotations:23.0.0')
     api('net.jodah:typetools:0.6.+')
 }

--- a/bus-jmh/build.gradle
+++ b/bus-jmh/build.gradle
@@ -49,4 +49,5 @@ tasks.register('jmh', JavaExec).configure {
     args    '-rff', project.file("${rootProject.buildDir}/jmh_results.txt")  // results file
     args    'net.neoforged.bus.benchmarks.FewListenersBenchmark'
     args    'net.neoforged.bus.benchmarks.ManyListenersBenchmark'
+    args    'net.neoforged.bus.benchmarks.ManyDifferentListenersBenchmark'
 }

--- a/bus-jmh/build.gradle
+++ b/bus-jmh/build.gradle
@@ -5,20 +5,12 @@ configurations {
 dependencies {
     implementation(rootProject)
     implementation(project(':bus-testjars'))
-    implementation('cpw.mods:modlauncher:10.0.+')
-    implementation('cpw.mods:securejarhandler:2.0.+')
     implementation('org.junit.jupiter:junit-jupiter-engine:5.8.+')
     implementation('org.apache.logging.log4j:log4j-core:2.17.1')
     implementation('org.apache.logging.log4j:log4j-api:2.17.1')
-    implementation('org.ow2.asm:asm:9.2')
-    implementation('org.ow2.asm:asm-tree:9.2')
-    implementation('org.ow2.asm:asm-commons:9.2')
     implementation('org.openjdk.jmh:jmh-core:1.35')
-    implementation('cpw.mods:bootstraplauncher:1.1.0')
     jmhOnly('org.openjdk.jmh:jmh-core:1.35')
     jmhOnly('org.openjdk.jmh:jmh-generator-annprocess:1.35')
-    jmhOnly('cpw.mods:bootstraplauncher:1.1.0')
-    jmhOnly('cpw.mods:securejarhandler:2.0.+')
     jmhOnly(sourceSets.main.output)
     compileOnly('org.jetbrains:annotations:23.0.0')
     runtimeOnly('org.apiguardian:apiguardian-api:1.1.2')
@@ -34,8 +26,6 @@ tasks.register('jmh', JavaExec).configure {
         '-p', sourceSets.main.runtimeClasspath.asPath,
         '--add-modules', 'ALL-MODULE-PATH',
         '--add-exports', 'net.neoforged.bus.jmh/net.neoforged.bus.benchmarks.jmh_generated=jmh.core',
-        '--add-opens', 'java.base/java.lang.invoke=cpw.mods.securejarhandler',
-        '--add-opens', 'java.base/java.lang.invoke=net.neoforged.bus',
     ]
     classpath = files(configurations.jmhOnly.asPath)
     mainClass = 'org.openjdk.jmh.Main'

--- a/bus-jmh/src/main/java/net/neoforged/bus/benchmarks/ManyDifferentListenersBenchmark.java
+++ b/bus-jmh/src/main/java/net/neoforged/bus/benchmarks/ManyDifferentListenersBenchmark.java
@@ -1,0 +1,91 @@
+package net.neoforged.bus.benchmarks;
+
+import net.neoforged.bus.api.*;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+@State(Scope.Benchmark)
+public class ManyDifferentListenersBenchmark {
+    private static final IEventBus BUS = BusBuilder.builder().build();
+
+    public static class TestEvent extends Event {
+        int x = 0;
+        int y = 0;
+    }
+
+    public static class TestCancellableEvent extends Event implements ICancellableEvent {
+        int x = 0;
+        int y = 0;
+    }
+
+    public static class Listeners {
+        private final int lookingFor;
+
+        public Listeners(int lookingFor) {
+            this.lookingFor = lookingFor;
+        }
+
+        @SubscribeEvent
+        public void onEvent(TestEvent evt) {
+            if (evt.x == lookingFor) {
+                evt.y++;
+            }
+        }
+
+        @SubscribeEvent
+        public void onEvent2(TestEvent evt) {
+            if (evt.x == lookingFor) {
+                evt.y++;
+            }
+        }
+
+        @SubscribeEvent
+        public void onEvent3(TestEvent evt) {
+            if (evt.x == lookingFor) {
+                evt.y++;
+            }
+        }
+
+        @SubscribeEvent
+        public void onEvent(TestCancellableEvent evt) {
+            if (evt.x == lookingFor) {
+                evt.y++;
+            }
+        }
+
+        @SubscribeEvent
+        public void onEvent2(TestCancellableEvent evt) {
+            if (evt.x == lookingFor) {
+                evt.y++;
+            }
+        }
+
+        @SubscribeEvent
+        public void onEvent3(TestCancellableEvent evt) {
+            if (evt.x == lookingFor) {
+                evt.y++;
+            }
+        }
+    }
+
+    @Setup
+    public void setup() {
+        for (int i = 0; i < 10; ++i) {
+            for (int j = 0; j < 10; ++j) {
+                BUS.register(new Listeners(j));
+            }
+        }
+    }
+
+    @Benchmark
+    public int testHundredListeners() {
+        return BUS.post(new TestEvent()).y;
+    }
+
+    @Benchmark
+    public int testHundredListenersCancellable() {
+        return BUS.post(new TestCancellableEvent()).y;
+    }
+}

--- a/bus-test/build.gradle
+++ b/bus-test/build.gradle
@@ -3,11 +3,8 @@ dependencies {
     implementation(rootProject)
     implementation(project(':bus-testjars'))
     implementation('org.junit.jupiter:junit-jupiter-api:5.8.+')
-    implementation('cpw.mods:modlauncher:10.0.+')
-    implementation('cpw.mods:securejarhandler:2.0.+')
     implementation('org.junit.jupiter:junit-jupiter-engine:5.8.+')
     implementation('org.apache.logging.log4j:log4j-core:2.17.1')
-    implementation('cpw.mods:bootstraplauncher:1.1.0')
     testCompileOnly('org.jetbrains:annotations:23.0.0')
     testRuntimeOnly('org.apiguardian:apiguardian-api:1.1.2')
 }
@@ -15,8 +12,4 @@ dependencies {
 test {
     useJUnitPlatform()
     forkEvery 1
-    jvmArgs(
-        '--add-opens', 'java.base/java.lang.invoke=cpw.mods.securejarhandler',
-        '--add-opens', 'java.base/java.lang.invoke=net.neoforged.bus',
-    )
 }

--- a/bus-testjars/src/main/java/net/neoforged/bus/testjar/TestListener.java
+++ b/bus-testjars/src/main/java/net/neoforged/bus/testjar/TestListener.java
@@ -1,9 +1,9 @@
 package net.neoforged.bus.testjar;
 
 import net.neoforged.bus.api.Event;
-import net.neoforged.bus.api.IEventListener;
+import net.neoforged.bus.api.EventListener;
 
-public class TestListener implements IEventListener {
+public class TestListener extends EventListener {
     private Object instance;
 
     TestListener(Object instance) {

--- a/src/main/java/net/neoforged/bus/ConsumerEventHandler.java
+++ b/src/main/java/net/neoforged/bus/ConsumerEventHandler.java
@@ -1,7 +1,7 @@
 package net.neoforged.bus;
 
 import net.neoforged.bus.api.Event;
-import net.neoforged.bus.api.IEventListener;
+import net.neoforged.bus.api.EventListener;
 
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -9,7 +9,7 @@ import java.util.function.Predicate;
 /**
  * Wraps a consumer to be used as an event handler, and overrides {@link #toString()} for better debugging.
  */
-public class ConsumerEventHandler implements IEventListener {
+public class ConsumerEventHandler extends EventListener {
     protected final Consumer<Event> consumer;
 
     public ConsumerEventHandler(Consumer<Event> consumer) {
@@ -28,7 +28,7 @@ public class ConsumerEventHandler implements IEventListener {
 
     public static class WithPredicate extends ConsumerEventHandler implements IWrapperListener {
         private final Predicate<Event> predicate;
-        private final IEventListener withoutCheck;
+        private final EventListener withoutCheck;
 
         public WithPredicate(Consumer<Event> consumer, Predicate<Event> predicate) {
             super(consumer);
@@ -44,7 +44,7 @@ public class ConsumerEventHandler implements IEventListener {
         }
 
         @Override
-        public IEventListener getWithoutCheck() {
+        public EventListener getWithoutCheck() {
             return withoutCheck;
         }
     }

--- a/src/main/java/net/neoforged/bus/EventBusErrorMessage.java
+++ b/src/main/java/net/neoforged/bus/EventBusErrorMessage.java
@@ -1,7 +1,7 @@
 package net.neoforged.bus;
 
 import net.neoforged.bus.api.Event;
-import net.neoforged.bus.api.IEventListener;
+import net.neoforged.bus.api.EventListener;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.util.StringBuilderFormattable;
 
@@ -12,10 +12,10 @@ import java.io.StringWriter;
 public class EventBusErrorMessage implements Message, StringBuilderFormattable {
     //private final Event event;
     private final int index;
-    private final IEventListener[] listeners;
+    private final EventListener[] listeners;
     private final Throwable throwable;
 
-    public EventBusErrorMessage(final Event event, final int index, final IEventListener[] listeners, final Throwable throwable) {
+    public EventBusErrorMessage(final Event event, final int index, final EventListener[] listeners, final Throwable throwable) {
         //this.event = event;
         this.index = index;
         this.listeners = listeners;

--- a/src/main/java/net/neoforged/bus/EventListenerFactory.java
+++ b/src/main/java/net/neoforged/bus/EventListenerFactory.java
@@ -3,9 +3,9 @@ package net.neoforged.bus;
 import net.neoforged.bus.api.Event;
 import net.neoforged.bus.api.IEventListener;
 import net.neoforged.bus.api.SubscribeEvent;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.objectweb.asm.*;
 
+import java.lang.constant.ConstantDescs;
 import java.lang.invoke.LambdaMetafactory;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -13,59 +13,98 @@ import java.lang.invoke.MethodType;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 
+import static org.objectweb.asm.Opcodes.*;
+
 /**
  * Manages generation of {@link IEventListener} instances from a {@link SubscribeEvent} method,
  * using {@link LambdaMetafactory}.
  */
 class EventListenerFactory {
-    private static final MethodHandles.Lookup IMPL_LOOKUP;
+    private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
+
+    private static final String[] HANDLER_INTERFACES = new String[]{Type.getInternalName(IEventListener.class)};
+
+    private static final String HANDLER_FUNC_DESC = Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(Event.class));
+    private static final String INSTANCE_FUNC_DESC = Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(Object.class), Type.getType(Event.class));
+
+    private static final MethodType STATIC_HANDLER = MethodType.methodType(void.class, Event.class);
+    private static final MethodType INSTANCE_HANDLER = MethodType.methodType(void.class, Object.class, Event.class);
+
+    private static final MethodType STATIC_CONSTRUCTOR = MethodType.methodType(void.class);
+    private static final MethodType INSTANCE_CONSTRUCTOR = MethodType.methodType(void.class, Object.class);
+
+    private static final ConstantDynamic METHOD_CONSTANT = new ConstantDynamic(ConstantDescs.DEFAULT_NAME, MethodHandle.class.descriptorString(), new Handle(
+        H_INVOKESTATIC, Type.getInternalName(MethodHandles.class), "classData",
+        MethodType.methodType(Object.class, MethodHandles.Lookup.class, String.class, Class.class).descriptorString(), false
+    ));
 
     private static final LockHelper<Method, MethodHandle> eventListenerFactories = LockHelper.withHashMap();
 
-    static {
+    private static MethodHandle getEventListenerFactory(Method m) {
+        return eventListenerFactories.computeIfAbsent(m, EventListenerFactory::createWrapper0);
+    }
+
+    private static MethodHandle createWrapper0(Method callback) {
         try {
-            var hackfield = MethodHandles.Lookup.class.getDeclaredField("IMPL_LOOKUP");
-            hackfield.setAccessible(true);
-            IMPL_LOOKUP = (MethodHandles.Lookup) hackfield.get(null);
-        } catch (Exception e) {
-            throw new RuntimeException("""
-        Failed to access IMPL_LOOKUP.
-        Maybe you need to add --add-opens="java.base/java.lang.invoke=net.neoforged.bus" to your JVM arguments.
-        """, e);
+            callback.setAccessible(true);
+
+            var handle = LOOKUP.unreflect(callback);
+            var isStatic = Modifier.isStatic(callback.getModifiers());
+
+            var boxedHandle = handle.asType(isStatic ? STATIC_HANDLER : INSTANCE_HANDLER);
+
+            var classBytes = makeClass(EventListenerFactory.class.getName() + "$" + callback.getName(), isStatic);
+            var classLookup = LOOKUP.defineHiddenClassWithClassData(classBytes, boxedHandle, true);
+            return classLookup.findConstructor(classLookup.lookupClass(), isStatic ? STATIC_CONSTRUCTOR : INSTANCE_CONSTRUCTOR);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException("Failed to create listener", e);
         }
     }
 
-    private static final MethodType LISTENER_INVOKE = MethodType.methodType(void.class, Event.class);
+    protected static byte[] makeClass(String name, boolean isStatic) {
+        ClassWriter cv = new ClassWriter(0);
 
-    private static MethodHandle getEventListenerFactory(Method m) {
-        return eventListenerFactories.computeIfAbsent(m, callback -> {
-            try {
-                var callbackClass = callback.getDeclaringClass();
-                var lookup = IMPL_LOOKUP.in(callbackClass);
+        String desc = name.replace('.', '/');
+        cv.visit(V16, ACC_PUBLIC | ACC_FINAL, desc, null, "java/lang/Object", HANDLER_INTERFACES);
 
-                if (Modifier.isStatic(callback.getModifiers())) {
-                    return LambdaMetafactory.metafactory(
-                            lookup,
-                            "invoke",
-                            MethodType.methodType(IEventListener.class),
-                            LISTENER_INVOKE,
-                            lookup.unreflect(callback),
-                            MethodType.methodType(void.class, callback.getParameterTypes()[0])
-                    ).getTarget();
-                } else {
-                    return LambdaMetafactory.metafactory(
-                            lookup,
-                            "invoke",
-                            MethodType.methodType(IEventListener.class, callbackClass),
-                            LISTENER_INVOKE,
-                            lookup.unreflect(callback),
-                            MethodType.methodType(void.class, callback.getParameterTypes()[0])
-                    ).getTarget();
-                }
-            } catch (Throwable e) {
-                throw new RuntimeException("Failed to create IEventListener factory", e);
+        cv.visitSource(".dynamic", null);
+        if (!isStatic) {
+            cv.visitField(ACC_PRIVATE | ACC_FINAL, "instance", "Ljava/lang/Object;", null, null).visitEnd();
+        }
+        {
+            MethodVisitor mv = cv.visitMethod(ACC_PUBLIC, "<init>", isStatic ? "()V" : "(Ljava/lang/Object;)V", null, null);
+            mv.visitCode();
+            mv.visitVarInsn(ALOAD, 0);
+            mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+            if (!isStatic) {
+                mv.visitVarInsn(ALOAD, 0);
+                mv.visitVarInsn(ALOAD, 1);
+                mv.visitFieldInsn(PUTFIELD, desc, "instance", "Ljava/lang/Object;");
             }
-        });
+            mv.visitInsn(RETURN);
+            mv.visitMaxs(2, 2);
+            mv.visitEnd();
+        }
+        {
+            MethodVisitor mv = cv.visitMethod(ACC_PUBLIC, "invoke", HANDLER_FUNC_DESC, null, null);
+            mv.visitCode();
+            mv.visitLdcInsn(METHOD_CONSTANT);
+            if (!isStatic) {
+                mv.visitVarInsn(ALOAD, 0);
+                mv.visitFieldInsn(GETFIELD, desc, "instance", "Ljava/lang/Object;");
+            }
+            mv.visitVarInsn(ALOAD, 1);
+            mv.visitMethodInsn(
+                INVOKEVIRTUAL, "java/lang/invoke/MethodHandle", "invokeExact",
+                isStatic ? HANDLER_FUNC_DESC : INSTANCE_FUNC_DESC, false
+            );
+            mv.visitInsn(RETURN);
+            mv.visitMaxs(3, 2);
+            mv.visitEnd();
+        }
+        cv.visitEnd();
+
+        return cv.toByteArray();
     }
 
     public static IEventListener create(Method callback, Object target) {

--- a/src/main/java/net/neoforged/bus/IWrapperListener.java
+++ b/src/main/java/net/neoforged/bus/IWrapperListener.java
@@ -1,10 +1,10 @@
 package net.neoforged.bus;
 
-import net.neoforged.bus.api.IEventListener;
+import net.neoforged.bus.api.EventListener;
 
 /**
  * Listener that wraps a listener to add a check.
  */
 public interface IWrapperListener {
-    IEventListener getWithoutCheck();
+    EventListener getWithoutCheck();
 }

--- a/src/main/java/net/neoforged/bus/SubscribeEventListener.java
+++ b/src/main/java/net/neoforged/bus/SubscribeEventListener.java
@@ -27,8 +27,8 @@ import static org.objectweb.asm.Type.getMethodDescriptor;
 /**
  * Wrapper around an event handler generated for a {@link SubscribeEvent} method.
  */
-class SubscribeEventListener implements IEventListener, IWrapperListener {
-    private final IEventListener handler;
+class SubscribeEventListener extends EventListener implements IWrapperListener {
+    private final EventListener handler;
     private final SubscribeEvent subInfo;
     private final boolean isGeneric;
     private String readable;
@@ -95,7 +95,7 @@ class SubscribeEventListener implements IEventListener, IWrapperListener {
     }
 
     @Override
-    public IEventListener getWithoutCheck() {
+    public EventListener getWithoutCheck() {
         return handler;
     }
 }

--- a/src/main/java/net/neoforged/bus/api/EventListener.java
+++ b/src/main/java/net/neoforged/bus/api/EventListener.java
@@ -23,7 +23,7 @@ package net.neoforged.bus.api;
 /**
  * Event listeners are wrapped with implementations of this interface
  */
-public interface IEventListener
+public abstract class EventListener
 {
-    void invoke(Event event);
+    public abstract void invoke(Event event);
 }

--- a/src/main/java/net/neoforged/bus/api/IEventBusInvokeDispatcher.java
+++ b/src/main/java/net/neoforged/bus/api/IEventBusInvokeDispatcher.java
@@ -1,5 +1,5 @@
 package net.neoforged.bus.api;
 
 public interface IEventBusInvokeDispatcher {
-    void invoke(IEventListener listener, Event event);
+    void invoke(EventListener listener, Event event);
 }

--- a/src/main/java/net/neoforged/bus/api/IEventExceptionHandler.java
+++ b/src/main/java/net/neoforged/bus/api/IEventExceptionHandler.java
@@ -31,5 +31,5 @@ public interface IEventExceptionHandler
      * @param index Index for the current listener being fired.
      * @param throwable The throwable being thrown
      */
-    void handleException(IEventBus bus, Event event, IEventListener[] listeners, int index, Throwable throwable);
+    void handleException(IEventBus bus, Event event, EventListener[] listeners, int index, Throwable throwable);
 }

--- a/src/main/java/net/neoforged/bus/api/SubscribeEvent.java
+++ b/src/main/java/net/neoforged/bus/api/SubscribeEvent.java
@@ -32,7 +32,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * {@link Event}.
  *
  * Use {@link IEventBus#register(Object)} to submit either an Object instance or a {@link Class} to the event bus
- * for scanning to generate callback {@link IEventListener} wrappers.
+ * for scanning to generate callback {@link EventListener} wrappers.
  *
  * The Event Bus system generates an ASM wrapper that dispatches to the marked method.
  */


### PR DESCRIPTION
As discussed on Discord. I'm currently submitting this as a PR against your fork as it builds on your existing branch, but happy to submit it to upstream if preferred.

 - Add an additional benchmark testing several heterogenous event listeners. There's probably better ways of doing this - I did debate creating 100 identical classes at runtime - but this seemed a good start.

 - Switch back to using ASM for generating event listeners. This uses the same approach as LMF, but avoiding the need to poke JDK internals. This is significantly slower (~20%) than LMF due to additional casts.

 - Convert `IEventListener` to an abstract class, making dynamic dispatch much faster. It might be nice to make this a sealed class, but that'd lift the minimum Java version to 17.

[Resulting benchmarks][benchmarks]. This doesn't reproduce the 40% gains seen previously (they're only 20% here), and more accurately demonstrates the tradeoff between the same-listener and many-listener cases.

I personally think it's still worth it - many different listeners is generally more common for Neo - but definitely worth discussing further :).

[benchmarks]: https://jmh.morethan.io/?sources=https://gist.githubusercontent.com/SquidDev/267e9abb64b0225d5f83e88b620766b7/raw/a18b3d200c14274f8d394883297bcad853352ac5/lmh.jmh.json,https://gist.githubusercontent.com/SquidDev/267e9abb64b0225d5f83e88b620766b7/raw/a18b3d200c14274f8d394883297bcad853352ac5/asm.jmh.json#details